### PR TITLE
Add nameWithOwner to repository GraphQL query

### DIFF
--- a/xkcd2347.py
+++ b/xkcd2347.py
@@ -83,6 +83,7 @@ class GitHub:
                         packageName
                         repository {
                           name
+                          nameWithOwner
                           owner {
                             login
                           }


### PR DESCRIPTION
For usability purposes having `nameWithOwner` as part of the query makes it convenient rather than having to stitch together the repository's name and owner's name.